### PR TITLE
chore(composer): update post-install-cmd to match the callable in Elgg

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     "phpunit/phpunit": "^4.7"
   },
   "scripts": {
-    "post-install-cmd": "\\Elgg\\Composer\\PostUpdate::execute",
-    "post-update-cmd": "\\Elgg\\Composer\\PostUpdate::execute",
+    "post-install-cmd": "\\Elgg\\Composer\\PostInstall::execute",
     "test": "phpunit"
   }
 }


### PR DESCRIPTION
The class PostUpdate was renamed PostInstall in Elgg because all the scripts are related to installing instead of updating. This also makes the post-update-cmd unnecessary, so it was removed.

Refs https://github.com/Elgg/Elgg/issues/8823
