### PR TITLE
chore(composer): Adds a script for the post update event

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "post-install-cmd": "\\Elgg\\Composer\\PostInstall::execute",
+    "post-package-update": "\\Elgg\\Composer\\PostUpdate::execute",
     "test": "phpunit"
   }
 }


### PR DESCRIPTION
@ewinslow Is it OK to have a separate class for post-install and post-update?

Alternative would be to use a single class and check whether the event passed in the class constructor is "install" or "update".
