### PR TITLE
Updated minimal version for Elgg requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
-    "elgg/elgg": "2.0.x-dev"
+    "elgg/elgg": "2.0.*"
   },
   "require-dev": {
     "srokap/code_review": "^1.0.5",


### PR DESCRIPTION
Since Elgg 2.x isn't in beta anymore, users could (automatically) upgrade between small updates.
